### PR TITLE
Dev 1042 fix indexer clean up

### DIFF
--- a/document_retriever_service/full_text_search_retriever_service.py
+++ b/document_retriever_service/full_text_search_retriever_service.py
@@ -126,6 +126,14 @@ def main():
         "--document_repository", help="Could be pairtree or local", default="local"
     )
 
+    # Path to the folder where the documents are stored. This parameter is useful for runing the script locally
+    parser.add_argument(
+        "--document_local_path",
+        help="Path of the folder where the documents (.xml file to index) are stored.",
+        required=False,
+        default=None
+    )
+
     args = parser.parse_args()
 
     document_generator = DocumentGenerator(db_conn)
@@ -134,11 +142,15 @@ def main():
         solr_api_catalog, document_generator
     )
 
-    document_local_path = "indexing_data"
+    document_local_folder = "indexing_data"
+    document_local_path = DOCUMENT_LOCAL_PATH
 
     # Create the directory to load the xml files if it does not exit
+
     try:
-        os.makedirs(os.path.join(DOCUMENT_LOCAL_PATH, document_local_path))
+        if args.document_local_path:
+            document_local_path = os.path.abspath(args.document_local_path)
+        os.makedirs(os.path.join(document_local_path, document_local_folder))
     except FileExistsError:
         pass
 
@@ -162,7 +174,7 @@ def main():
         solr_str = create_solr_string(entry)
         logger.info(f"Creating XML file to index")
         with open(
-                f"/{os.path.join(DOCUMENT_LOCAL_PATH, document_local_path)}/{namespace}{file_name}_solr_full_text.xml",
+                f"/{os.path.join(document_local_path, document_local_folder)}/{namespace}{file_name}_solr_full_text.xml",
                 "w",
         ) as f:
             f.write(solr_str)

--- a/ht_indexer_api/ht_indexer_api.py
+++ b/ht_indexer_api/ht_indexer_api.py
@@ -17,14 +17,14 @@ class HTSolrAPI:
         response = requests.get(self.url)
         return response
 
-    def index_document(self, path: Text):
+    def index_document(self, path: Path, list_documents: list = None):
         """Read an XML and feed into SOLR for indexing"""
-        data_path = Path(path)  # Path(f"{os.path.dirname(__file__)}/{path}")
-        list_documents = glob.glob(f"{data_path}/*.xml")
+        data_path = Path(path)
         for doc in list_documents:
-            doc = doc.replace(" ", "+")
-            logger.info(f"Indexing {doc}")
-            with open(doc, "rb") as xml_file:
+            doc_path = f"{data_path}/{doc}"
+            doc_path = doc_path.replace(" ", "+")
+            logger.info(f"Indexing {doc_path}")
+            with open(doc_path, "rb") as xml_file:
                 data_dict = xml_file.read()
                 response = requests.post(
                     f"{self.url.replace('#/', '')}update/?commit=true",
@@ -38,11 +38,11 @@ class HTSolrAPI:
         return response
 
     def get_documents(
-        self,
-        query: str = None,
-        response_format: Text = "json",
-        start: int = 0,
-        rows: int = 100,
+            self,
+            query: str = None,
+            response_format: Text = "json",
+            start: int = 0,
+            rows: int = 100,
     ):
         data_query = {"q": "*:*"}
         if query:

--- a/ht_indexer_api/ht_indexer_api_test.py
+++ b/ht_indexer_api/ht_indexer_api_test.py
@@ -24,7 +24,8 @@ class TestHTSolrAPI:
 
     def test_index_document_add(self, get_solrAPI):
         document_path = Path(f"{os.path.dirname(__file__)}/data/add")
-        response = get_solrAPI.index_document(document_path)
+        list_documents = ["39015078560292_solr_full_text.xml"]
+        response = get_solrAPI.index_document(document_path, list_documents=list_documents)
         assert response.status_code == 200
 
     def test_query_by_id(self, get_solrAPI):
@@ -39,11 +40,12 @@ class TestHTSolrAPI:
         assert response.status_code == 200
         assert (
                 response.headers["Content-Type"] == "text/plain;charset=utf-8"
-        )  # "application/json;charset=utf-8"
+        )
 
     def test_index_document_delete(self, get_solrAPI):
         document_path = Path(
             f"{os.path.dirname(__file__)}/data/delete"
         )  # "data/delete"
-        response = get_solrAPI.index_document(document_path)
+        list_documents = ["39015078560292-1-1-flat.solr_delete.xml"]
+        response = get_solrAPI.index_document(document_path, list_documents=list_documents)
         assert response.status_code == 200

--- a/main.py
+++ b/main.py
@@ -45,9 +45,9 @@ def main():
         return {"status": response.status_code, "description": response.headers}
 
     @app.post("/solrIndexing/")
-    def solr_indexing(path):
+    def solr_indexing(path, list_documents: list = None):
         """Read an XML and feed into SOLR for indexing"""
-        response = solr_api.index_document(path)
+        response = solr_api.index_document(path, list_documents=list_documents)
         return {"status": response.status_code, "description": response.headers}
 
     @app.post("/solrQuery/")


### PR DESCRIPTION
**This PR is to solve the following issue**:

-  The function to index the generated XML file did not clean up the folder. We should remove the file once we index it, otherwise it will be indexed several times
- The folder to store and read the generated XML file was hardcode

**The changes:**

- I have update the documentation
- I have added one parameter to the python scripts to generate and index the document to be able to define the folder to store/read the generated XML.

*  These changes, does not affect the current pipeline in kubernetes because it was only for running test locally, for that reason I won't update the image yet.

**Additional note**: Any new change on this repository have become complex for testing for any other members of the team. There are several components involved. I will create some tasks for next sprint to split up each components, their tests and also to make sure we have the flow for testing with sample data each component.