### PR TITLE
refactoring to split complex functions in smaller ones; reuse the com…

### DIFF
--- a/catalog_metadata/catalog_metadata_test.py
+++ b/catalog_metadata/catalog_metadata_test.py
@@ -1,4 +1,3 @@
-import json
 import os
 from copy import deepcopy
 
@@ -7,27 +6,6 @@ import pytest
 from catalog_metadata.catalog_metadata import CatalogItemMetadata, CatalogRecordMetadata
 
 current = os.path.dirname(__file__)
-
-
-# Retrieve JSON file to create a dictionary with a catalog record
-@pytest.fixture()
-def get_record_data():
-    with open(os.path.join(current, "data/catalog.json"), "r", ) as file:
-        data = json.load(file)
-
-    return data
-
-
-# Use the catalog record to create a CatalogRecordMetadata object
-@pytest.fixture()
-def get_catalog_record_metadata(get_record_data):
-    return CatalogRecordMetadata(get_record_data)
-
-
-# Create a CatalogItemMetadata object with the catalog record and the ht_id of the item
-@pytest.fixture()
-def get_item_metadata(get_record_data: dict, get_catalog_record_metadata: CatalogRecordMetadata):
-    return CatalogItemMetadata("mdp.39015078560292", get_catalog_record_metadata)
 
 
 # Update some fields of the catalog record to test some functions that retrieve specific fields

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,75 @@
+import pytest
+import json
+import os
+
+from catalog_metadata.catalog_metadata import CatalogRecordMetadata, CatalogItemMetadata
+from document_retriever_service.catalog_retriever_service import CatalogRetrieverService
+from ht_queue_service.queue_consumer import QueueConsumer
+from ht_queue_service.queue_producer import QueueProducer
+
+current = os.path.dirname(__file__)
+
+
+# Fixtures to retrieve the catalog record
+# Retrieve JSON file to create a dictionary with a catalog record
+@pytest.fixture()
+def get_record_data():
+    """JSON file containing the catalog record"""
+    with open(os.path.join(current, "catalog_metadata/data/catalog.json"), "r", ) as file:
+        data = json.load(file)
+    return data
+
+
+# Use the catalog record to create a CatalogRecordMetadata object
+@pytest.fixture()
+def get_catalog_record_metadata(get_record_data):
+    return CatalogRecordMetadata(get_record_data)
+
+
+# Create a CatalogItemMetadata object with the catalog record and the ht_id of the item
+@pytest.fixture()
+def get_item_metadata(get_record_data: dict, get_catalog_record_metadata: CatalogRecordMetadata):
+    return CatalogItemMetadata("mdp.39015078560292", get_catalog_record_metadata)
+
+
+# CatalogRetrieverService object to retrieve the catalog record
+@pytest.fixture
+def get_catalog_retriever_service(solr_api_url):
+    return CatalogRetrieverService(solr_api_url)
+
+
+@pytest.fixture
+def solr_api_url():
+    return "http://solr-sdr-catalog:9033/solr/#/catalog/"
+
+
+# Fixtures to instantiate the queue consumer and producer
+@pytest.fixture
+def retriever_parameters(request):
+    """
+    This function is used to create the parameters for the queue
+    """
+    return request.param
+
+
+@pytest.fixture
+def consumer_instance(retriever_parameters):
+    """
+    This function is used to consume messages from the queue
+    """
+
+    return QueueConsumer(retriever_parameters["user"], retriever_parameters["password"],
+                         retriever_parameters["host"], retriever_parameters["queue_name"],
+                         retriever_parameters["dead_letter_queue"],
+                         retriever_parameters["requeue_message"])
+
+
+@pytest.fixture
+def producer_instance(retriever_parameters):
+    """
+    This function is used to generate a message to the queue
+    """
+
+    return QueueProducer(retriever_parameters["user"], retriever_parameters["password"],
+                         retriever_parameters["host"], retriever_parameters["queue_name"],
+                         retriever_parameters["dead_letter_queue"])

--- a/document_retriever_service/catalog_retriever_service.py
+++ b/document_retriever_service/catalog_retriever_service.py
@@ -11,15 +11,32 @@ from ht_utils.query_maker import make_query
 logger = get_ht_logger(name=__name__)
 
 
-def create_catalog_object_by_record_id(record, catalog_record_metadata, results):
-    for item_id in record.get('ht_id'):  # Append list of CatalogMetadata object
+def create_catalog_object_by_record_id(record: dict, catalog_record_metadata: CatalogRecordMetadata,
+                                       results: list) -> list[CatalogItemMetadata]:
+    """Receive a record and return a list of item, and their metadata
+    :param record: dict with catalog record (retrieve from Solr)
+    :param catalog_record_metadata: CatalogRecordMetadata object
+    :param results: list of CatalogItemMetadata object
+    """
+
+    for item_id in record.get('ht_id'):
         results.append(CatalogRetrieverService.get_catalog_object(item_id, catalog_record_metadata))
 
     return results
 
 
-def create_catalog_object_by_item_id(list_documents, record, catalog_record_metadata, results):
-    # TODO: To optimize the process, we could remove the item included in results from the list_documents
+def create_catalog_object_by_item_id(list_documents: list, record: dict,
+                                     catalog_record_metadata: CatalogRecordMetadata, results: list) \
+        -> list[CatalogItemMetadata]:
+    """Receive a list of documents and a catalog record;
+    Search for the item (ht_id) in the list and then;
+    Create the CatalogMetadata object for each document in the list
+    :param list_documents: list of ht_id
+    :param record: dict with catalog record (retrieve from Solr)
+    :param catalog_record_metadata: CatalogRecordMetadata object
+    :param results: list of CatalogItemMetadata object
+    """
+
     for item_id in record.get('ht_id'):
         if item_id in list_documents:
             results.append(CatalogRetrieverService.get_catalog_object(item_id, catalog_record_metadata))
@@ -49,7 +66,11 @@ class CatalogRetrieverService:
     def count_documents(self, list_documents, start, rows, by_field: str = 'item'):
 
         """
-        This method is used to load the list of ht_id from the Catalog index
+        This method counts the number of documents to process having the list of documents
+        :param list_documents: list of ids to process
+        :param start: start index
+        :param rows: number of rows to retrieve
+        :param by_field: field to search by (item=ht_id or record=id)
         """
         # Build the query to retrieve the total of documents to process
         query = make_query(list_documents, by_field)
@@ -61,32 +82,19 @@ class CatalogRetrieverService:
             total_records = output.get("response").get("numFound")
             logger.info(f" Total of records {total_records}")
 
-            if total_records:
-                return total_records
-            else:
-                return 0
-
+            return total_records if total_records else 0
         except Exception as e:
             logger.error(f"Error in getting documents from Solr {e}")
             raise e
 
-    def retrieve_documents(self, list_documents: list[str], start: int, rows: int, by_field: str = 'item'):
+    def retrieve_documents_from_solr(self, list_documents: list, start: int, rows: int, by_field: str = 'item'):
 
+        """Function to retrieve documents from Solr
+        :param list_documents: list of documents to retrieve from Solr index
+        :param start: start index
+        :param rows: number of rows to retrieve
+        :param by_field: field to search by (item or record)
         """
-        Input: list of ht_id
-
-        by_field: 'item' or 'record'
-
-        Create the query, if only one item, so the query will be ht_id: item_id
-        if more than one item, the query will be ht_id: (item_id1 OR item_id2 OR item_id3)
-        This method is used to retrieve the documents from the Catalog, then it will be used to return instances
-        of a CatalogMetadata
-
-        """
-
-        count_records = 0
-
-        results = []
 
         # try ... except block to catch any exception raised by the Solr connection
         try:
@@ -99,6 +107,29 @@ class CatalogRetrieverService:
         except Exception as e:
             logger.error(f"Error in getting documents from Solr {e}")
             raise e
+
+        return output
+
+    def retrieve_documents(self, list_documents: list[str], start: int, rows: int, by_field: str = 'item') \
+            -> list[CatalogItemMetadata]:
+
+        """
+        This method is used to retrieve the documents from the Catalog. For each document is generated a CatalogMedata
+         object. The output of this method is a list of CatalogMetadata objects
+        :param list_documents: list of documents to retrieve
+        :param start: start index
+        :param rows: number of rows to retrieve
+        :param by_field: use this field to create the Solr query. item=ht_id and record=id
+            Create the query, if only one item, so the query will be ht_id: item_id
+         if more than one item, the query will be ht_id: (item_id1 OR item_id2 OR item_id3)
+        """
+
+        count_records = 0
+
+        results = []
+
+        # Query Solr to retrieve the documents
+        output = self.retrieve_documents_from_solr(list_documents, start, rows, by_field)
 
         # If no documents are found, output.get("response").get("docs") is an empty list
         logger.info(f" {output.get('response').get('numFound')} documents found in Solr to process")
@@ -157,12 +188,12 @@ def main():
     rows = 100
 
     # TODO Implement the use case that retrieve documents accept a query instead of a list of documents
-    for result in catalog_retrieval_service.retrieve_documents(start, rows):
-        for record in result:
-            item_id = record.ht_id
-            logger.info(f"Item id: {item_id}")
-            file_object.write(f"{item_id}\n")
-            count = count + 1
+    list_documents = []
+    for result in catalog_retrieval_service.retrieve_documents(list_documents, start, rows, by_field='record'):
+        item_id = result.ht_id
+        logger.info(f"Item id: {item_id}")
+        file_object.write(f"{item_id}\n")
+        count = count + 1
 
     file_object.close()
     logger.info(count)

--- a/document_retriever_service/full_text_search_retriever_service.py
+++ b/document_retriever_service/full_text_search_retriever_service.py
@@ -6,6 +6,7 @@ import time
 import multiprocessing
 
 import ht_utils.ht_utils
+from catalog_metadata.catalog_metadata import CatalogItemMetadata
 from document_retriever_service.catalog_retriever_service import CatalogRetrieverService
 from document_retriever_service.retriever_arguments import RetrieverServiceArguments
 from ht_utils.ht_logger import get_ht_logger
@@ -20,9 +21,11 @@ sys.path.insert(0, parent)
 PROCESSES = multiprocessing.cpu_count() - 1
 
 
-def publish_document(queue_producer, content: dict = None):
+def publish_document(queue_producer: QueueProducer, content: dict = None):
     """
     Publish the document in a queue
+    :param queue_producer: QueueProducer object
+    :param content: dict with the content of the message
     """
     message = content
     logger.info(f"Sending message with id {content.get('ht_id')} to queue {queue_producer.queue_name}")
@@ -54,6 +57,77 @@ class FullTextSearchRetrieverQueueService:
         self.queue_password = queue_password
         self.dead_letter_queue = dead_letter_queue
 
+    def get_queue_producer(self) -> QueueProducer:
+
+        """Establish a connection to the queue to publish the documents"""
+
+        try:
+            queue_producer = QueueProducer(self.queue_user, self.queue_password, self.queue_host, self.queue_name,
+                                           self.dead_letter_queue)
+        except Exception as e:
+            logger.error(f"Environment variables required: "
+                         f"{ht_utils.ht_utils.get_general_error_message('DocumentGeneratorService', e)}")
+
+        return queue_producer
+
+    @staticmethod
+    def generate_metadata(record: CatalogItemMetadata) -> tuple[dict, str]:
+
+        """ Generate the metadata and the ht_id of the document to be published in the queue"""
+
+        item_id = record.ht_id
+        logger.info(f"Processing document {item_id}")
+
+        item_metadata = record.metadata
+        item_metadata['ht_id'] = item_id
+
+        return item_metadata, item_id
+
+    @staticmethod
+    def count_documents(catalog_retriever, initial_documents, start, rows, by_field: str = 'item'):
+
+        """Count the number of documents retrieved from the Catalog
+        param catalog_retriever: CatalogRetrieverService object
+        param initial_documents: list of documents to process
+        param start: start index
+        param rows: number of rows to retrieve
+        param by_field: field to search by (item=ht_id or record=id)
+        """
+
+        try:
+            total_documents = catalog_retriever.count_documents(initial_documents, start, rows, by_field)
+        except Exception as e:
+            error_info = ht_utils.ht_utils.get_general_error_message("FullTextSearchRetrieverQueueService",
+                                                                     e)
+            logger.error(f"Error in getting documents from Solr {error_info}")
+            exit(1)
+        return total_documents
+
+    @staticmethod
+    def publishing_documents(queue_producer, result):
+
+        processed_items = []
+        for record in result:
+
+            item_metadata, item_id = FullTextSearchRetrieverQueueService.generate_metadata(record)
+
+            logger.info(f"Publishing document {item_id}")
+
+            # Try to publish the document in the queue, if an error occurs, log the error and continue to the next
+            # TODO: Add a mechanism to send the message to a dead letter queue
+            try:
+                publish_document(queue_producer, item_metadata)
+
+                # Update the status of the item in a table
+                processed_items.append(item_id)
+            except Exception as e:
+                error_info = ht_utils.ht_utils.get_error_message_by_document("FullTextSearchRetrieverQueueService",
+                                                                             e, item_metadata)
+
+                logger.error(f"Error in publishing document {item_id} {error_info}")
+                continue
+        return processed_items
+
     def full_text_search_retriever_service(self, initial_documents, start, rows, by_field: str = 'item'):
         """
         This method is used to retrieve the documents from the Catalog and generate the full text search entry
@@ -62,27 +136,18 @@ class FullTextSearchRetrieverQueueService:
         # Create a connection to Solr Api
         catalog_retriever = CatalogRetrieverService(self.solr_api_url)
 
-        try:
-            # Create a connection to the queue
-            queue_producer = QueueProducer(self.queue_user, self.queue_password, self.queue_host, self.queue_name,
-                                           self.dead_letter_queue)
-        except Exception as e:
-            logger.error(f"Environment variables required: "
-                         f"{ht_utils.ht_utils.get_general_error_message('DocumentGeneratorService', e)}")
-        try:
-            total_documents = catalog_retriever.count_documents(initial_documents, start, rows, by_field)
-        except Exception as e:
-            error_info = ht_utils.ht_utils.get_general_error_message("FullTextSearchRetrieverQueueService",
-                                                                     e)
+        # Create a connection to the queue to produce messages
+        queue_producer = self.get_queue_producer()
 
-            logger.error(f"Error in getting documents from Solr {error_info}")
-            exit(1)
-
+        total_documents = FullTextSearchRetrieverQueueService.count_documents(catalog_retriever, initial_documents,
+                                                                              start, rows, by_field)
         count_records = 0
         processed_items = []
         while count_records < total_documents:
+
             chunk = initial_documents[count_records:count_records + rows]
 
+            # If there is something with Solr retrieving a chunk of documents will try to retrieve the next chunk
             try:
                 result = catalog_retriever.retrieve_documents(chunk, start, rows, by_field=by_field)
             except Exception as e:
@@ -92,28 +157,10 @@ class FullTextSearchRetrieverQueueService:
                 logger.error(f"Error in getting documents from Solr {error_info}")
                 continue
 
-            for record in result:
-                item_id = record.ht_id
-                logger.info(f"Processing document {item_id}")
+            # Publish the documents in the queue
+            processed_chunk_items = FullTextSearchRetrieverQueueService.publishing_documents(queue_producer, result)
 
-                # publish the document in a queue
-                item_metadata = record.metadata
-                item_metadata['ht_id'] = item_id
-                logger.info(f"Publishing document {item_id}")
-
-                # Try to publish the document in the queue, if an error occurs, log the error and continue to the next
-                # TODO: Add a mechanism to send the message to a dead letter queue
-                try:
-                    publish_document(queue_producer, item_metadata)
-
-                    # Update the status of the item in a table
-                    processed_items.append(item_id)
-                except Exception as e:
-                    error_info = ht_utils.ht_utils.get_error_message_by_document("FullTextSearchRetrieverQueueService",
-                                                                                 e, item_metadata)
-
-                    logger.error(f"Error in publishing document {item_id} {error_info}")
-                    continue
+            processed_items.extend(processed_chunk_items)
 
             count_records += len(result)
             logger.info(f"Total of processed items {count_records}")
@@ -179,7 +226,7 @@ def main():
         logger.error("Error: `query` and `query fields` parameters required")
         sys.exit(1)
 
-    document_indexer_service = FullTextSearchRetrieverQueueService(
+    document_retriever_service = FullTextSearchRetrieverQueueService(
         init_args_obj.solr_api_url,
         init_args_obj.queue_name,
         init_args_obj.queue_host,
@@ -199,7 +246,7 @@ def main():
     nthreads = None
 
     total_documents = len(list_documents)
-    run_retriever_service(parallelize, nthreads, total_documents, list_documents, by_field, document_indexer_service,
+    run_retriever_service(parallelize, nthreads, total_documents, list_documents, by_field, document_retriever_service,
                           init_args_obj.start, init_args_obj.rows)
 
     logger.info(f"Total time to retrieve and generate documents {time.time() - start_time:.10f}")

--- a/document_retriever_service/full_text_search_retriever_service_test.py
+++ b/document_retriever_service/full_text_search_retriever_service_test.py
@@ -1,28 +1,63 @@
+import pytest
+
+from document_retriever_service.full_text_search_retriever_service import FullTextSearchRetrieverQueueService
+
+
+@pytest.fixture
+def get_document_retriever_service(solr_api_url):
+    return FullTextSearchRetrieverQueueService(solr_api_url,
+                                               "test_producer_queue",
+                                               "rabbitmq",
+                                               "guest",
+                                               "guest",
+                                               True
+                                               )
+
+
 class TestFullTextRetrieverService:
 
-    def test_publish_document(self):
-        # TODO Use the json file to index the document without the need to connect to the Catalog
-        pass
+    def test_full_text_service_count_documents(self, get_catalog_retriever_service):
+        list_documents = ['nyp.33433082002258', 'not_exist_document']
 
-    def test_full_text_search_retriever_(self):
-        # TODO Use the json file to index the document without the need to connect to the Catalog
-        pass
+        count_docs = FullTextSearchRetrieverQueueService.count_documents(get_catalog_retriever_service,
+                                                                         list_documents,
+                                                                         0,
+                                                                         1,
+                                                                         "item")
 
-    """
-    def test_create_directory_to_load_xml_fields(self):
-        document_local_path = "indexing_data"
+        assert 1 == count_docs
 
-        # Create the directory to load the xml files if it does not exit
-        try:
-            os.makedirs(os.path.join("/tmp", document_local_path))
-        except FileExistsError:
-            pass
-        assert os.path.exists(os.path.join("/tmp", document_local_path)) == True
-        # Copy an XML file for testing
-        shutil.copy(
-            os.path.join(parentdir, "data/document_generator/fullrecord.xml"),
-            "/tmp/indexing_data",
+    def test_generate_metadata(self, get_item_metadata):
+        list_documents = ['mdp.39015078560292']
+
+        metadata, item_id = FullTextSearchRetrieverQueueService.generate_metadata(get_item_metadata)
+
+        assert metadata.get("ht_id") == list_documents[0]
+        assert metadata.get('countryOfPubStr') == ['India']
+        assert item_id == list_documents[0]
+
+    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
+                                                       "queue_name": "test_producer_queue",
+                                                       "requeue_message": False,
+                                                       "dead_letter_queue": True,
+                                                       "query_field": "item",
+                                                       "start": 0,
+                                                       "rows": 100}])
+    def test_full_text_search_retriever_service(self, retriever_parameters, get_document_retriever_service,
+                                                consumer_instance):
+        # Clean up the queue
+        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
+
+        list_documents = ['nyp.33433082002258', 'not_exist_document']
+
+        get_document_retriever_service.full_text_search_retriever_service(
+            list_documents,
+            retriever_parameters["start"],
+            retriever_parameters["rows"],
+            retriever_parameters["query_field"]
         )
 
-        assert os.path.exists("/tmp/indexing_data/fullrecord.xml") == True
-    """
+        assert 1 == consumer_instance.conn.get_total_messages()
+
+        # Clean up the queue
+        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)

--- a/document_retriever_service/run_retriever_service_by_file.py
+++ b/document_retriever_service/run_retriever_service_by_file.py
@@ -32,6 +32,8 @@ def retrieve_documents_by_file(solr_api_url, queue_name, queue_host, queue_user,
     :param start: Start Solr query
     :param rows: rows
     :param status_file: Status file
+    :param parallelize: Boolean parameter to parallelize the process
+    :param nthreads: Number of threads
     """
 
     document_indexer_service = FullTextSearchRetrieverQueueService(

--- a/document_retriever_service/run_retriever_service_by_file_test.py
+++ b/document_retriever_service/run_retriever_service_by_file_test.py
@@ -3,14 +3,8 @@ import os
 
 from document_retriever_service.run_retriever_service_by_file import retrieve_documents_by_file
 from document_retriever_service.ht_status_retriever_service import get_non_processed_ids
-from ht_queue_service.queue_consumer import QueueConsumer
 
 current = os.path.dirname(__file__)
-
-
-@pytest.fixture
-def solr_api_url():
-    return "http://localhost:8983/solr/catalog"
 
 
 @pytest.fixture()
@@ -23,26 +17,6 @@ def get_input_file():
 def get_status_file():
     """TXT file containing the list of items to process"""
     return os.path.join(current, "document_retriever_status_test.txt")
-
-
-@pytest.fixture
-def retriever_parameters(request):
-    """
-    This function is used to create the parameters for the queue
-    """
-    return request.param
-
-
-@pytest.fixture
-def consumer_instance(retriever_parameters):
-    """
-    This function is used to generate a message
-    """
-
-    return QueueConsumer(retriever_parameters["user"], retriever_parameters["password"],
-                         retriever_parameters["host"], retriever_parameters["queue_name"],
-                         retriever_parameters["dead_letter_queue"],
-                         retriever_parameters["requeue_message"])
 
 
 class TestRunRetrieverServiceByFile:

--- a/ht_queue_service/queue_consumer_test.py
+++ b/ht_queue_service/queue_consumer_test.py
@@ -3,7 +3,6 @@ import pytest
 import time
 
 from ht_queue_service.queue_consumer import QueueConsumer, positive_acknowledge
-from ht_queue_service.queue_producer import QueueProducer
 
 from ht_utils.ht_logger import get_ht_logger
 
@@ -32,38 +31,7 @@ def list_messages():
 
 
 @pytest.fixture
-def queue_parameters(request):
-    """
-    This function is used to create the parameters for the queue
-    """
-    return request.param
-
-
-@pytest.fixture
-def producer_instance(queue_parameters):
-    """
-    This function is used to generate a message
-    """
-
-    return QueueProducer(queue_parameters["user"], queue_parameters["password"],
-                         queue_parameters["host"], queue_parameters["queue_name"],
-                         queue_parameters["dead_letter_queue"])
-
-
-@pytest.fixture
-def consumer_instance(queue_parameters):
-    """
-    This function is used to generate a message
-    """
-
-    return QueueConsumer(queue_parameters["user"], queue_parameters["password"],
-                         queue_parameters["host"], queue_parameters["queue_name"],
-                         queue_parameters["dead_letter_queue"],
-                         queue_parameters["requeue_message"])
-
-
-@pytest.fixture
-def populate_queue(list_messages, producer_instance, consumer_instance, queue_parameters):
+def populate_queue(list_messages, producer_instance, consumer_instance, retriever_parameters):
     """ Test for re-queueing a message from the queue, an error is raised, and the message is routed
             to the dead letter queue and discarded from the main queue"""
 
@@ -111,9 +79,9 @@ def populate_queue(list_messages, producer_instance, consumer_instance, queue_pa
 
 class TestHTConsumerService:
 
-    @pytest.mark.parametrize("queue_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
-                                                   "queue_name": "test_producer_queue", "dead_letter_queue": True,
-                                                   "requeue_message": False}])
+    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
+                                                       "queue_name": "test_producer_queue", "dead_letter_queue": True,
+                                                       "requeue_message": False}])
     def test_queue_consume_message(self, one_message, producer_instance, consumer_instance):
         """ Test for consuming a message from the queue
         One message is published and consumed, then at the end of the test the queue is empty
@@ -132,9 +100,9 @@ class TestHTConsumerService:
 
         assert 0 == consumer_instance.conn.get_total_messages()
 
-    @pytest.mark.parametrize("queue_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
-                                                   "queue_name": "test_producer_queue", "dead_letter_queue": True,
-                                                   "requeue_message": False}])
+    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
+                                                       "queue_name": "test_producer_queue", "dead_letter_queue": True,
+                                                       "requeue_message": False}])
     def test_queue_consume_message_empty(self, consumer_instance):
         """ Test for consuming a message from an empty queue"""
 
@@ -143,7 +111,7 @@ class TestHTConsumerService:
 
         assert 0 == consumer_instance.conn.get_total_messages()
 
-    @pytest.mark.parametrize("queue_parameters",
+    @pytest.mark.parametrize("retriever_parameters",
                              [{"user": "guest", "password": "guest", "host": "rabbitmq",
                                "queue_name": "test_producer_queue", "dead_letter_queue": True,
                                "requeue_message": False}])
@@ -160,7 +128,7 @@ class TestHTConsumerService:
 
         check_consumer.conn.ht_channel.queue_purge(check_consumer.queue_name)
 
-    @pytest.mark.parametrize("queue_parameters",
+    @pytest.mark.parametrize("retriever_parameters",
                              [{"user": "guest", "password": "guest", "host": "rabbitmq",
                                "queue_name": "test_producer_queue", "dead_letter_queue": True,
                                "requeue_message": True}])

--- a/ht_queue_service/queue_producer_test.py
+++ b/ht_queue_service/queue_producer_test.py
@@ -1,6 +1,5 @@
 import pytest
 
-from ht_queue_service.queue_producer import QueueProducer
 import multiprocessing
 import time
 import copy
@@ -24,28 +23,9 @@ def create_list_message():
     return list_message
 
 
-@pytest.fixture
-def queue_parameters(request):
-    """
-    This function is used to create the parameters for the queue
-    """
-    return request.param
-
-
-@pytest.fixture
-def producer_instance(queue_parameters):
-    """
-    This function is used to generate a message
-    """
-
-    return QueueProducer(queue_parameters["user"], queue_parameters["password"],
-                         queue_parameters["host"], queue_parameters["queue_name"],
-                         queue_parameters["dead_letter_queue"])
-
-
 class TestHTProducerService:
-    @pytest.mark.parametrize("queue_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
-                                                   "queue_name": "test_producer_queue", "dead_letter_queue": True}])
+    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
+                                                       "queue_name": "test_producer_queue", "dead_letter_queue": True}])
     def test_queue_produce_one_message(self, producer_instance):
         producer_instance.publish_messages(message)
         assert producer_instance.conn.get_total_messages() == 1
@@ -65,8 +45,8 @@ class TestHTProducerService:
 
         logger.info(f"Time taken = {time.time() - start:.10f}")
 
-    @pytest.mark.parametrize("queue_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
-                                                   "queue_name": "test_producer_queue", "dead_letter_queue": True}])
+    @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
+                                                       "queue_name": "test_producer_queue", "dead_letter_queue": True}])
     def test_queue_reconnect(self, producer_instance):
         # Check if the connection is open
         assert producer_instance.conn.queue_connection.is_open


### PR DESCRIPTION
This PR refactoring different functions of the package document_retriever_service. The goal was to split complex functions into smaller ones to improve code reliability. 

As new functions were created, new unit tests were added. A conftest.py script was created to reuse common fixtures for different unit tests. For that reason, the packages ht_queue_service and catalog_metadata changes on this PR.

How do you test this PR?

1. Clone the repository
`git clone ... or git fetch`

2. Use the branch of this PR
`git checkout DEV-1160-run_documents_batch`

3. In the working directory,
    3.1. Create the image
          `docker build -t document_generator .`
    3.2. Run the container
          `docker compose up document_retriever -d`
    3.3. Run python test
           `docker compose exec document_retriever pytest`

If all the tests worked fine, you will the following output on your terminal
<img width="1117" alt="image" src="https://github.com/hathitrust/ht_indexer/assets/47088146/5984c16f-e7f3-420a-bae2-ad7f1381920f">
