### PR TITLE
create a subclass to connect to RabbitMQ using the dead letter queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 #PYTHON image
-#Given the speed improvements in 3.11, more important than the base image is making sure you’re on an up-to-date release of Python.
+#Given the speed improvements in 3.11, more important than the base image is making sure you're on an up-to-date release of Python.
 # I will choose the official Docker Python image because it has
 # the absolute latest bugfix version of Python
-# it has the absolute latest system packages, the official Docker Python image is still your best bet, since it’s based on Debian Bookworm, released June 2023
+# it has the absolute latest system packages, the official Docker Python image is still your best bet, since it's based on Debian Bookworm, released June 2023
 # Debian 12 and the size is 51MB
 
 #I abandonded alpine image because it lacks the package installer pip and the support for installing wheel packages, which are both needed for installing applications like Pandas and Numpy.
@@ -20,8 +20,6 @@ ENV PYTHONUNBUFFERED=1\
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100
 
-USER root
-
 WORKDIR /app
 
 ENV PYTHONPATH "${PYTHONPATH}:/app"
@@ -33,7 +31,7 @@ RUN set -ex \
     && addgroup --system --gid 1001 appgroup \
     && adduser --system --uid 1001 --gid 1001 --no-create-home appuser
 
-    # Upgrade the package index and install security upgrades
+# Upgrade the package index and install security upgrades
 RUN apt-get update -y \
     && apt-get upgrade -y \
     && apt-get -y install build-essential \
@@ -56,10 +54,10 @@ RUN  python3.11 -m pip install -r requirements.txt
 FROM python-base as development
 ENV FASTAPI_ENV=development
 
-WORKDIR /app
 
 COPY . .
-
-CMD ["tail", "-f", "/dev/null"]
+RUN chown appuser:appgroup -R /app/
 
 USER appuser
+
+CMD ["tail", "-f", "/dev/null"]

--- a/conftest.py
+++ b/conftest.py
@@ -60,7 +60,6 @@ def consumer_instance(retriever_parameters):
 
     return QueueConsumer(retriever_parameters["user"], retriever_parameters["password"],
                          retriever_parameters["host"], retriever_parameters["queue_name"],
-                         retriever_parameters["dead_letter_queue"],
                          retriever_parameters["requeue_message"])
 
 
@@ -71,5 +70,4 @@ def producer_instance(retriever_parameters):
     """
 
     return QueueProducer(retriever_parameters["user"], retriever_parameters["password"],
-                         retriever_parameters["host"], retriever_parameters["queue_name"],
-                         retriever_parameters["dead_letter_queue"])
+                         retriever_parameters["host"], retriever_parameters["queue_name"])

--- a/document_generator/generator_arguments.py
+++ b/document_generator/generator_arguments.py
@@ -50,7 +50,7 @@ class GeneratorServiceArguments:
                             help="Could be pairtree or local", default="local"
                             )
 
-        # Path to the folder where the documents are stored. This parameter is useful for runing the script locally
+        # Path to the folder where the documents are stored. This parameter is useful for running the script locally
         parser.add_argument("--document_local_path",
                             help="Path of the folder where the documents (.xml file to index) are stored.",
                             required=False,
@@ -73,7 +73,6 @@ class GeneratorServiceArguments:
                                                     os.environ["SRC_QUEUE_PASS"],
                                                     os.environ["SRC_QUEUE_HOST"],
                                                     os.environ["SRC_QUEUE_NAME"],
-                                                    dead_letter_queue=True,
                                                     requeue_message=False)
         except KeyError as e:
             logger.error(f"Environment variables required: "
@@ -93,8 +92,7 @@ class GeneratorServiceArguments:
                 self.tgt_queue_producer = QueueProducer(os.environ["TGT_QUEUE_USER"],
                                                         os.environ["TGT_QUEUE_PASS"],
                                                         os.environ["TGT_QUEUE_HOST"],
-                                                        os.environ["TGT_QUEUE_NAME"],
-                                                        dead_letter_queue=True)
+                                                        os.environ["TGT_QUEUE_NAME"])
             except KeyError as e:
                 logger.error(f"Environment variables required: "
                              f"{ht_utils.ht_utils.get_general_error_message('DocumentGeneratorService', e)}")

--- a/document_indexer_service/indexer_arguments.py
+++ b/document_indexer_service/indexer_arguments.py
@@ -39,7 +39,6 @@ class IndexerServiceArguments:
                                                 os.environ["QUEUE_PASS"],
                                                 os.environ["QUEUE_HOST"],
                                                 os.environ["QUEUE_NAME"],
-                                                dead_letter_queue=True,
                                                 requeue_message=False)
         except KeyError as e:
             logger.error(f"Environment variables required: "

--- a/document_retriever_service/full_text_search_retriever_service.py
+++ b/document_retriever_service/full_text_search_retriever_service.py
@@ -47,23 +47,20 @@ class FullTextSearchRetrieverQueueService:
                  solr_api_url,
                  queue_name: str = 'retriever_queue', queue_host: str = None,
                  queue_user: str = None,
-                 queue_password: str = None,
-                 dead_letter_queue: bool = False):
+                 queue_password: str = None):
 
         self.solr_api_url = solr_api_url
         self.queue_name = queue_name
         self.queue_host = queue_host
         self.queue_user = queue_user
         self.queue_password = queue_password
-        self.dead_letter_queue = dead_letter_queue
 
     def get_queue_producer(self) -> QueueProducer:
 
         """Establish a connection to the queue to publish the documents"""
 
         try:
-            queue_producer = QueueProducer(self.queue_user, self.queue_password, self.queue_host, self.queue_name,
-                                           self.dead_letter_queue)
+            queue_producer = QueueProducer(self.queue_user, self.queue_password, self.queue_host, self.queue_name)
         except Exception as e:
             logger.error(f"Environment variables required: "
                          f"{ht_utils.ht_utils.get_general_error_message('DocumentGeneratorService', e)}")
@@ -231,8 +228,7 @@ def main():
         init_args_obj.queue_name,
         init_args_obj.queue_host,
         init_args_obj.queue_user,
-        init_args_obj.queue_password,
-        init_args_obj.dead_letter_queue)
+        init_args_obj.queue_password)
 
     by_field = init_args_obj.query_field
     list_documents = init_args_obj.list_documents

--- a/document_retriever_service/full_text_search_retriever_service_test.py
+++ b/document_retriever_service/full_text_search_retriever_service_test.py
@@ -9,8 +9,7 @@ def get_document_retriever_service(solr_api_url):
                                                "test_producer_queue",
                                                "rabbitmq",
                                                "guest",
-                                               "guest",
-                                               True
+                                               "guest"
                                                )
 
 
@@ -39,7 +38,6 @@ class TestFullTextRetrieverService:
     @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
                                                        "queue_name": "test_producer_queue",
                                                        "requeue_message": False,
-                                                       "dead_letter_queue": True,
                                                        "query_field": "item",
                                                        "start": 0,
                                                        "rows": 100}])

--- a/document_retriever_service/retriever_arguments.py
+++ b/document_retriever_service/retriever_arguments.py
@@ -44,7 +44,6 @@ class RetrieverServiceArguments:
             self.queue_host = os.environ["QUEUE_HOST"]
             self.queue_user = os.environ["QUEUE_USER"]
             self.queue_password = os.environ["QUEUE_PASS"]
-            self.dead_letter_queue = True
         except KeyError as e:
             logger.error(f"Environment variables required: "
                          f"{ht_utils.ht_utils.get_general_error_message('DocumentGeneratorService', e)}")

--- a/document_retriever_service/run_retriever_service_by_file.py
+++ b/document_retriever_service/run_retriever_service_by_file.py
@@ -1,4 +1,4 @@
-"""This an use case for testing and process a huge lis of documents extracted from production environment."""
+"""This use case is for testing and processing a huge lis of documents extracted from the production environment."""
 import argparse
 import os
 import sys
@@ -16,7 +16,7 @@ parent = os.path.dirname(current)
 sys.path.insert(0, parent)
 
 
-def retrieve_documents_by_file(solr_api_url, queue_name, queue_host, queue_user, queue_password, dead_letter_queue,
+def retrieve_documents_by_file(solr_api_url, queue_name, queue_host, queue_user, queue_password,
                                input_documents_file, query_field, start, rows, status_file, parallelize, nthreads):
     """ This method is used to retrieve the documents from the Catalog and generate the full text search entry.
     The list of documents to index is extracted from a file.
@@ -26,7 +26,6 @@ def retrieve_documents_by_file(solr_api_url, queue_name, queue_host, queue_user,
     :param queue_host: Queue host
     :param queue_user: Queue user
     :param queue_password: Queue password
-    :param dead_letter_queue: Boolean parameter indicating the error messages will send to a dead letter queue
     :param input_documents_file: File with the list of documents to process
     :param query_field: Query field
     :param start: Start Solr query
@@ -41,8 +40,7 @@ def retrieve_documents_by_file(solr_api_url, queue_name, queue_host, queue_user,
         queue_name,
         queue_host,
         queue_user,
-        queue_password,
-        dead_letter_queue)
+        queue_password)
 
     if os.path.isfile(input_documents_file):
         with open(input_documents_file) as f:
@@ -89,7 +87,7 @@ def main():
     nthreads = None
 
     retrieve_documents_by_file(init_args_obj.solr_api_url, init_args_obj.queue_name, init_args_obj.queue_host,
-                               init_args_obj.queue_user, init_args_obj.queue_password, init_args_obj.dead_letter_queue,
+                               init_args_obj.queue_user, init_args_obj.queue_password,
                                init_args_obj.input_documents_file, init_args_obj.query_field,
                                init_args_obj.start, init_args_obj.rows,
                                status_file, parallelize, nthreads)

--- a/document_retriever_service/run_retriever_service_by_file_test.py
+++ b/document_retriever_service/run_retriever_service_by_file_test.py
@@ -33,7 +33,6 @@ class TestRunRetrieverServiceByFile:
                                                        "user": "guest", "password": "guest", "host": "rabbitmq",
                                                        "queue_name": "test_producer_queue",
                                                        "requeue_message": False,
-                                                       "dead_letter_queue": True,
                                                        "query_field": "item",
                                                        "start": 0,
                                                        "rows": 100}])
@@ -50,7 +49,6 @@ class TestRunRetrieverServiceByFile:
                                    retriever_parameters["host"],
                                    retriever_parameters["user"],
                                    retriever_parameters["password"],
-                                   retriever_parameters["dead_letter_queue"],
                                    get_input_file,
                                    retriever_parameters["query_field"],
                                    retriever_parameters["start"],

--- a/ht_queue_service/queue_connection.py
+++ b/ht_queue_service/queue_connection.py
@@ -1,72 +1,9 @@
 import pika
 
 
-def ht_declare_dead_letter_queue(ht_channel: pika.connection, queue_name: str):
-    """
-    Declare the dead letter queue
-    """
-
-    # Check if the queue exist
-    # Declare a queue
-    # durable=True - the queue will survive a broker restart
-    # exclusive=False - the queue can be accessed in other channels
-    # auto_delete=False - the queue won't be deleted once the consumer is disconnected
-    # arguments - the dead-letter-exchange and dead-letter-routing-key are used to define the dead letter exchange
-    # and the routing key to use when a message is dead-lettered.
-    ht_channel.queue_declare(queue=queue_name, durable=True, exclusive=False, auto_delete=False,
-                             arguments={'x-dead-letter-exchange': 'dlx',
-                                        "x-dead-letter-routing-key": f"dlx_key_{queue_name}"}
-                             )
-
-
-def ht_queue_connection(queue_connection: pika.BlockingConnection, ht_exchange: str, queue_name: str,
-                        dead_letter_queue: bool = True):
-    # queue a name is important when you want to share the queue between producers and consumers
-
-    # channel - a channel is a virtual connection inside a connection
-    # get a channel
-    ht_channel = queue_connection.channel()
-
-    # exchange - this can be assumed as a bridge name which needed to be declared so that queues can be accessed
-    # declare the exchange
-    # Direct – the exchange forwards the message to a queue based on a routing key
-    ht_channel.exchange_declare(ht_exchange, durable=True, exchange_type="direct", auto_delete=False)
-
-    # We use a dead-letter-exchange to handle messages that are not processed successfully.
-    # The dead-letter-exchange is an exchange to which messages will be re-routed if they are rejected by the queue.
-    # See a detail explanation of dead letter exchanges here: https://www.rabbitmq.com/docs/dlx#overview
-    # A message is dead-lettered if it is negatively acknowledged and requeued, or if it times out.
-
-    if dead_letter_queue:
-        # Declare the dead letter exchange
-        ht_channel.exchange_declare("dlx", durable=True, exchange_type="direct")
-
-        # Declare the dead letter exchange to the original queue
-        ht_declare_dead_letter_queue(ht_channel, queue_name)
-
-        # Declare the dead letter queue
-        ht_channel.queue_declare(f"{queue_name}_dead_letter_queue")
-
-        # Bind the dead letter exchange to the dead letter queue
-        # The queue_bind method binds a queue to an exchange. The queue will now receive messages from the exchange,
-        # otherwise no messages will be routed to the queue.
-        ht_channel.queue_bind(f"{queue_name}_dead_letter_queue", "dlx", f"dlx_key_{queue_name}")
-
-    # The relationship between exchange and a queue is called a binding.
-    # Link the exchange to the queue to send messages.
-    ht_channel.queue_bind(exchange=ht_exchange, queue=queue_name, routing_key=queue_name)
-
-    # The value defines the max number of unacknowledged deliveries that are permitted on a channel.
-    # When the number reaches the configured count, RabbitMQ will stop delivering more messages on the
-    # channel until at least one of the outstanding ones is acknowledged.
-    ht_channel.basic_qos(prefetch_count=1)
-
-    return ht_channel
-
-
 class QueueConnection:
 
-    def __init__(self, user: str, password: str, host: str, queue_name: str, dead_letter_queue: bool = True):
+    def __init__(self, user: str, password: str, host: str, queue_name: str):
         # Define credentials (user/password) as environment variables
         # declaring the credentials needed for connection like host, port, username, password, exchange etc.
 
@@ -76,25 +13,41 @@ class QueueConnection:
             self.host = host
             self.queue_name = queue_name
             self.exchange = 'ht_channel'
-            self.dead_letter_queue = dead_letter_queue
 
             # Open a connection to RabbitMQ
             self.queue_connection = pika.BlockingConnection(pika.ConnectionParameters(host=self.host,
                                                                                       credentials=self.credentials,
                                                                                       heartbeat=0))
-            self.ht_channel = ht_queue_connection(self.queue_connection, self.exchange, self.queue_name,
-                                                  dead_letter_queue=self.dead_letter_queue)
+            self.ht_channel = self.ht_queue_connection()
         except Exception as e:
             raise e
-        
+
+    def ht_queue_connection(self):
+        # queue a name is important when you want to share the queue between producers and consumers
+
+        # channel - a channel is a virtual connection inside a connection
+        # get a channel
+        ht_channel = self.queue_connection.channel()
+
+        # exchange - this can be assumed as a bridge name which needed to be declared so that queues can be accessed
+        # declare the exchange
+        # Direct – the exchange forwards the message to a queue based on a routing key
+        ht_channel.exchange_declare(self.exchange, durable=True, exchange_type="direct", auto_delete=False)
+
+        ht_channel.queue_bind(self.queue_name, self.exchange, routing_key=self.queue_name)
+
+        # The value defines the max number of unacknowledged deliveries that are permitted on a channel.
+        # When the number reaches the configured count, RabbitMQ will stop delivering more messages on the
+        # channel until at least one of the outstanding ones is acknowledged.
+        ht_channel.basic_qos(prefetch_count=1)
+
+        return ht_channel
+
     def queue_reconnect(self):
-        self.__init__(self.credentials.username, self.credentials.password, self.host, self.queue_name,
-                      self.dead_letter_queue)
-        if self.dead_letter_queue:
-            ht_declare_dead_letter_queue(self.ht_channel, self.queue_name)
+        self.__init__(self.credentials.username, self.credentials.password, self.host, self.queue_name)
 
     def get_total_messages(self):
         # durable: Survive reboots of the broker
         # passive: Only check to see if the queue exists and raise `ChannelClosed` if it doesn't
-        status = self.ht_channel.queue_declare(queue=self.queue_name, durable=True, passive=True)
+        status = self.ht_channel.queue_declare(self.queue_name, durable=True, passive=True)
         return status.method.message_count

--- a/ht_queue_service/queue_connection_dead_letter.py
+++ b/ht_queue_service/queue_connection_dead_letter.py
@@ -1,0 +1,67 @@
+import pika
+from ht_queue_service.queue_connection import QueueConnection
+
+
+def ht_declare_dead_letter_queue(ht_channel: pika.connection, queue_name: str):
+    """
+    Declare the dead letter queue
+    """
+
+    # durable=True - the queue will survive a broker restart
+    # exclusive=False - the queue can be accessed in other channels
+    # auto_delete=False - the queue won't be deleted once the consumer is disconnected
+    # arguments - the dead-letter-exchange and dead-letter-routing-key are used to define the dead letter exchange
+    # and the routing key to use when a message is dead-lettered.
+    ht_channel.queue_declare(queue=queue_name, durable=True, exclusive=False, auto_delete=False,
+                             arguments={'x-dead-letter-exchange': 'dlx',
+                                        "x-dead-letter-routing-key": f"dlx_key_{queue_name}"}
+                             )
+
+
+class QueueConnectionDeadLetter(QueueConnection):
+    """
+    We use a dead-letter-exchange to handle messages that are not processed successfully.
+    The dead-letter-exchange is an exchange to which messages will be re-routed if they are rejected by the queue.
+    See a detail explanation of dead letter exchanges here: https://www.rabbitmq.com/docs/dlx#overview
+    A message is dead-lettered if it is negatively acknowledged and requeued, or if it times out.
+    """
+
+    def __init__(self, user: str, password: str, host: str, queue_name: str):
+        # Call the parent class constructor that initializes the connection to the queue
+        super().__init__(user, password, host, queue_name)
+
+    def ht_queue_connection(self):
+        # queue a name is important when you want to share the queue between producers and consumers
+        # channel - a channel is a virtual connection inside a connection
+        # get a channel
+        ht_channel = self.queue_connection.channel()
+
+        # exchange - this can be assumed as a bridge name which needed to be declared so that queues can be accessed
+        # declare the exchange
+        # Direct – the exchange forwards the message to a queue based on a routing key
+        ht_channel.exchange_declare(self.exchange, durable=True, exchange_type="direct", auto_delete=False)
+
+        # Declare the dead letter exchange
+        ht_channel.exchange_declare("dlx", durable=True, exchange_type="direct")
+
+        # Declare the dead letter exchange to the original queue
+        ht_declare_dead_letter_queue(ht_channel, self.queue_name)
+
+        # Declare the dead letter queue
+        ht_channel.queue_declare(f"{self.queue_name}_dead_letter_queue")
+
+        # Bind the dead letter exchange to the dead letter queue
+        # The queue_bind method binds a queue to an exchange. The queue will now receive messages from the exchange,
+        # otherwise no messages will be routed to the queue.
+        ht_channel.queue_bind(f"{self.queue_name}_dead_letter_queue", "dlx", f"dlx_key_{self.queue_name}")
+
+        # The relationship between exchange and a queue is called a binding.
+        # Link the exchange to the queue to send messages.
+        ht_channel.queue_bind(self.queue_name, self.exchange, routing_key=self.queue_name)
+
+        # The value defines the max number of unacknowledged deliveries that are permitted on a channel.
+        # When the number reaches the configured count, RabbitMQ will stop delivering more messages on the
+        # channel until at least one of the outstanding ones is acknowledged.
+        ht_channel.basic_qos(prefetch_count=1)
+
+        return ht_channel

--- a/ht_queue_service/queue_consumer.py
+++ b/ht_queue_service/queue_consumer.py
@@ -1,7 +1,5 @@
 # consumer
-
-
-from ht_queue_service.queue_connection import QueueConnection
+from ht_queue_service.queue_connection_dead_letter import QueueConnectionDeadLetter
 from ht_utils.ht_logger import get_ht_logger
 
 logger = get_ht_logger(name=__name__)
@@ -12,7 +10,7 @@ def positive_acknowledge(used_channel, basic_deliver):
 
 
 class QueueConsumer:
-    def __init__(self, user: str, password: str, host: str, queue_name: str, dead_letter_queue: bool = True,
+    def __init__(self, user: str, password: str, host: str, queue_name: str,
                  requeue_message: bool = False):
 
         """
@@ -21,7 +19,6 @@ class QueueConsumer:
         :param password: password for the RabbitMQ
         :param host: host for the RabbitMQ
         :param queue_name: name of the queue
-        :param dead_letter_queue: boolean to enable dead letter queue
         :param requeue_message: boolean to requeue the message to the queue
         """
 
@@ -34,8 +31,7 @@ class QueueConsumer:
         self.requeue_message = requeue_message
 
         try:
-            self.conn = QueueConnection(self.user, self.password, self.host, self.queue_name,
-                                        dead_letter_queue=dead_letter_queue)
+            self.conn = QueueConnectionDeadLetter(self.user, self.password, self.host, self.queue_name)
         except Exception as e:
             raise e
 

--- a/ht_queue_service/queue_producer.py
+++ b/ht_queue_service/queue_producer.py
@@ -1,7 +1,7 @@
 # producer
 import json
 
-from ht_queue_service.queue_connection import QueueConnection
+from ht_queue_service.queue_connection_dead_letter import QueueConnectionDeadLetter
 from ht_utils.ht_logger import get_ht_logger
 
 logger = get_ht_logger(name=__name__)
@@ -10,14 +10,13 @@ logger = get_ht_logger(name=__name__)
 class QueueProducer:
     """ Create a class to send messages to a rabbitMQ """
 
-    def __init__(self, user: str, password: str, host: str, queue_name: str, dead_letter_queue: bool = True):
+    def __init__(self, user: str, password: str, host: str, queue_name: str):
         """
 
         :param user: username for the RabbitMQ
         :param password: password for the RabbitMQ
         :param host: host for the RabbitMQ
         :param queue_name: name of the queue
-        :param dead_letter_queue: boolean to enable dead letter queue
         """
         # Define credentials (user/password) as environment variables
         # declaring the credentials needed for connection like host, port, username, password, exchange etc
@@ -28,8 +27,7 @@ class QueueProducer:
         self.password = password
 
         try:
-            self.conn = QueueConnection(self.user, self.password, self.host, self.queue_name,
-                                        dead_letter_queue=dead_letter_queue)
+            self.conn = QueueConnectionDeadLetter(self.user, self.password, self.host, self.queue_name)
         except Exception as e:
             raise e
 

--- a/ht_queue_service/queue_producer_test.py
+++ b/ht_queue_service/queue_producer_test.py
@@ -25,7 +25,7 @@ def create_list_message():
 
 class TestHTProducerService:
     @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
-                                                       "queue_name": "test_producer_queue", "dead_letter_queue": True}])
+                                                       "queue_name": "test_producer_queue"}])
     def test_queue_produce_one_message(self, producer_instance):
         producer_instance.publish_messages(message)
         assert producer_instance.conn.get_total_messages() == 1
@@ -46,7 +46,7 @@ class TestHTProducerService:
         logger.info(f"Time taken = {time.time() - start:.10f}")
 
     @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
-                                                       "queue_name": "test_producer_queue", "dead_letter_queue": True}])
+                                                       "queue_name": "test_producer_queue"}])
     def test_queue_reconnect(self, producer_instance):
         # Check if the connection is open
         assert producer_instance.conn.queue_connection.is_open


### PR DESCRIPTION
This PR is about this [task](https://hathitrust.atlassian.net/browse/DEV-1188) and consists of creating a new class to connect to RabbitMQ using a dead letter queue. 

The change of this PR does not introduce a new feature, it is also improving the readability of this repository. 

All the services that use a queue have been updated to utilize the new class and remove the parameter _dead_letter_queue_. Additionally, some tests have been updated. 

In the Dockerfile, the ownership of the /app folder was updated to resolve an issue identified in Kubernetes.
**How to test it?**

1. Clone the repository
`git clone ... or git fetch`

2. Use the branch of this PR
`git checkout -b DEV-1188-queueConnection-subclass`

3. In the working directory,

3.1. Create the image
`docker build -t document_generator .`

3.2. Run the container
 `docker compose up document_generator -d`

3.3. Run Python tests related to document_generator_service
`docker compose exec document_generator pytest document_generator ht_document ht_queue_service ht_utils`

If you see the image below in your terminal, the PR is working fine.

<img width="980" alt="image" src="https://github.com/hathitrust/ht_indexer/assets/47088146/ff3d1860-06d2-4d94-b846-ea8488864b22">

