### PR TITLE
refactoring generate full_text document module. Avoid processing MACOSX files

### DIFF
--- a/catalog_metadata/catalog_metadata_test.py
+++ b/catalog_metadata/catalog_metadata_test.py
@@ -37,7 +37,8 @@ def get_item_metadata_second_position(update_catalog_record_metadata: dict,
 def get_catalog_record_without_enum_pubdate(get_record_data):
     updating_record = deepcopy(get_record_data)
     updating_record[
-        "ht_json"] = '[{"htid":"nyp.33433069877805","newly_open":null,"ingest":"20220501","rights":["pdus",null],"heldby":["nypl"],"collection_code":"nyp","enumcron":"v. 1","dig_source":"google"}]'
+        "ht_json"] = ('[{"htid":"nyp.33433069877805","newly_open":null,"ingest":"20220501","rights":["pdus",null],'
+                      '"heldby":["nypl"],"collection_code":"nyp","enumcron":"v. 1","dig_source":"google"}]')
     updating_record["ht_id"] = ["nyp.33433069877805"]
     return updating_record
 

--- a/ht_indexer_api/ht_indexer_api_test.py
+++ b/ht_indexer_api/ht_indexer_api_test.py
@@ -7,61 +7,61 @@ from ht_indexer_api.ht_indexer_api import HTSolrAPI
 
 
 @pytest.fixture
-def get_solrAPI():
+def get_solr_api():
     return HTSolrAPI(
         url="http://solr-lss-dev:8983/solr/#/core-x/"
     )
 
 
 @pytest.fixture
-def get_fake_solrAPI():
+def get_fake_solr_api():
     return HTSolrAPI(
         url="http://solr-lss-dev:8983/solr/#/core-not_exist/"
     )
 
 
 class TestHTSolrAPI:
-    def test_connection(self, get_solrAPI):
+    def test_connection(self, get_solr_api):
         """
         Check if solr server is running
         :param get_solrAPI:
         :return:
         """
-        solr_api_status = get_solrAPI.get_solr_status()
+        solr_api_status = get_solr_api.get_solr_status()
         assert solr_api_status.status_code == 200
 
-    def test_index_document_add(self, get_solrAPI):
+    def test_index_document_add(self, get_solr_api):
         document_path = Path(f"{os.path.dirname(__file__)}/data/add")
         list_documents = ["39015078560292_solr_full_text.xml"]
-        response = get_solrAPI.index_documents(document_path, list_documents=list_documents, solr_url_json="update/",
-                                               headers={"Content-Type": "application/xml"})
+        response = get_solr_api.index_documents(document_path, list_documents=list_documents, solr_url_json="update/",
+                                                headers={"Content-Type": "application/xml"})
         assert response.status_code == 200
 
-    def test_query_by_id(self, get_solrAPI):
+    def test_query_by_id(self, get_solr_api):
         """
 
         :param get_solrAPI:
         :return:
         """
         query = "oclc:23549320"
-        response = get_solrAPI.get_documents(query=query, response_format="json")
+        response = get_solr_api.get_documents(query=query, response_format="json")
 
         assert response.status_code == 200
         assert (
                 response.headers["Content-Type"] == "text/plain;charset=utf-8"
         )
 
-    def test_index_document_delete(self, get_solrAPI):
+    def test_index_document_delete(self, get_solr_api):
         document_path = Path(
             f"{os.path.dirname(__file__)}/data/delete"
         )  # "data/delete"
         list_documents = ["39015078560292-1-1-flat.solr_delete.xml"]
-        response = get_solrAPI.index_documents(document_path, list_documents=list_documents, solr_url_json="update/",
-                                               headers={"Content-Type": "application/xml"})
+        response = get_solr_api.index_documents(document_path, list_documents=list_documents, solr_url_json="update/",
+                                                headers={"Content-Type": "application/xml"})
         assert response.status_code == 200
 
-    def test_get_documents_failed(self, get_fake_solrAPI):
+    def test_get_documents_failed(self, get_fake_solr_api):
         query = "*:*"
 
         with pytest.raises(Exception, match=""):
-            response = get_fake_solrAPI.get_documents(query, response_format="json")
+            response = get_fake_solr_api.get_documents(query, response_format="json")

--- a/ht_queue_service/queue_consumer_test.py
+++ b/ht_queue_service/queue_consumer_test.py
@@ -100,6 +100,7 @@ class TestHTConsumerService:
             break
 
         assert 0 == consumer_instance.conn.get_total_messages()
+        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
 
     @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
                                                        "queue_name": "test_producer_queue",
@@ -111,6 +112,7 @@ class TestHTConsumerService:
         consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
 
         assert 0 == consumer_instance.conn.get_total_messages()
+        consumer_instance.conn.ht_channel.queue_purge(consumer_instance.queue_name)
 
     @pytest.mark.parametrize("retriever_parameters",
                              [{"user": "guest", "password": "guest", "host": "rabbitmq",

--- a/ht_queue_service/queue_producer_test.py
+++ b/ht_queue_service/queue_producer_test.py
@@ -27,6 +27,7 @@ class TestHTProducerService:
     @pytest.mark.parametrize("retriever_parameters", [{"user": "guest", "password": "guest", "host": "rabbitmq",
                                                        "queue_name": "test_producer_queue"}])
     def test_queue_produce_one_message(self, producer_instance):
+        producer_instance.conn.ht_channel.queue_purge(producer_instance.queue_name)
         producer_instance.publish_messages(message)
         assert producer_instance.conn.get_total_messages() == 1
         producer_instance.conn.ht_channel.queue_purge(producer_instance.queue_name)
@@ -62,3 +63,5 @@ class TestHTProducerService:
 
         # Check if the connection is open
         assert producer_instance.conn.queue_connection.is_open
+
+        producer_instance.conn.ht_channel.queue_purge(producer_instance.queue_name)

--- a/ht_utils/sample_data/sample_data_generator.py
+++ b/ht_utils/sample_data/sample_data_generator.py
@@ -1,14 +1,12 @@
-from ht_document.ht_document import HtDocument
-from ht_utils.ht_logger import get_ht_logger
-
-logger = get_ht_logger(name=__name__)
-
-from random import shuffle
 import json
 import os
 import inspect
+from ht_document.ht_document import HtDocument
+from ht_utils.ht_logger import get_ht_logger
+from random import shuffle
 from typing import List
 
+logger = get_ht_logger(name=__name__)
 currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
 

--- a/ht_utils/text_processor.py
+++ b/ht_utils/text_processor.py
@@ -1,9 +1,13 @@
 import re
-from io import BytesIO
 from typing import Dict, List
 from xml.sax.saxutils import quoteattr
 
 from ht_utils.ht_logger import get_ht_logger
+
+
+class MathLibraryError(Exception):
+    pass
+
 
 table = str.maketrans(
     {
@@ -22,7 +26,7 @@ def xmlesc(txt):
     return txt.translate(table)
 
 
-def string_preparation(doc_content: BytesIO) -> str:
+def string_preparation(doc_content: bytes) -> str:
     """
     Clean up a byte object and convert it to string
     :param doc_content: XML string
@@ -33,11 +37,11 @@ def string_preparation(doc_content: BytesIO) -> str:
     try:
         # Convert byte to str
         str_content = str(doc_content.decode())
-    except Exception as e:
+    except UnicodeDecodeError as e:
         logger.error(f"File encode incompatible with UTF-8 {e}")
-        raise UnicodeDecodeError
+        raise e
 
-    # Remove line breaks
+        # Remove line breaks
     str_content = str_content.replace("\n", " ")
 
     # Remove extra white spaces
@@ -58,10 +62,10 @@ def field_tag(key, value) -> str:
 
 def create_solr_string(data_dic: Dict) -> str:
     """
-    Function to convert a dictionary into an xml string uses for indexing a document in Solr index
+    Function to convert a dictionary into a xml string uses for indexing a document in Solr index
 
     :param data_dic: Dictionary with the data will be indexed in Solr
-    :return: XML String  with tag <add> for adding the document in Solr
+    :return: XML String with tag <add> for adding the document in Solr
     """
     solr_doc = []
     nl = "\n"


### PR DESCRIPTION
This PR is about this [task](https://hathitrust.atlassian.net/browse/DEV-1186) and consists of refactoring the script that generated the full-text document.

The change of this PR does not introduce a new feature, it is also improving the readability of this repository.

Some tests have been updated and one test that generates a UnicodeDecodeError, [task](https://hathitrust.atlassian.net/browse/DEV-1185) has been investigated and generated.

**How to test it?**

**Clone the repository**
`git clone ... or git fetch`

**Use the branch of this PR**
`git checkout -b DEV-1186-refactoring_generate-docs`

**In the working directory**,

**3.1. Create the image**
_docker build -t document_generator ._

**3.2. Run the container**
`docker compose up document_generator -d`

3.3. Run Python tests related to document_generator_service
`docker compose exec document_generator pytest document_generator ht_document ht_queue_service ht_utils`

If you see the image below in your terminal, the PR is working fine.

![image](https://github.com/hathitrust/ht_indexer/assets/47088146/087fd57f-1e19-4f6f-b4cf-c6f827d49ad6)
