### PR TITLE
Dev 1234 fix pairtree path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,6 @@ services:
     depends_on:
       solr-sdr-catalog:
         condition: service_healthy
-      solr-lss-dev:
-        condition: service_healthy
-      mysql-sdr:
-        condition: service_healthy
       rabbitmq:
         condition: service_healthy
     tty: true
@@ -101,6 +97,8 @@ services:
       - ../sdr1/obj:/sdr1/obj
     depends_on:
       rabbitmq:
+        condition: service_healthy
+      mysql-sdr:
         condition: service_healthy
     tty: true
     stdin_open: true

--- a/document_generator/document_generator_test.py
+++ b/document_generator/document_generator_test.py
@@ -9,6 +9,7 @@ import pytest
 from _pytest.outcomes import Failed
 
 from document_generator.full_text_document_generator import FullTextDocumentGenerator
+from document_generator.mysql_data_extractor import extract_namespace_and_id
 from ht_utils.text_processor import string_preparation
 
 current = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
@@ -90,3 +91,28 @@ class TestDocumentGenerator:
 
         assert len(all_field.strip()) == len(get_allfield_string.strip())
         assert all_field.strip() == get_allfield_string.strip()
+
+    def test_extract_namespace_and_id(self):
+        """
+        Extracts the namespace and the id from a given document id string.
+        The namespace is defined as the characters before the first period.
+        The id is the remainder of the string after the first period.
+
+        :param document_id: The document id string to extract from.
+        :return: A tuple containing the namespace and the id.
+        """
+
+        document_id = "uc2.ark:/13960/t4mk66f1d"
+        namespace, id = extract_namespace_and_id(document_id)
+        assert namespace == "uc2"
+        assert id == "ark:/13960/t4mk66f1d"
+
+        document_id = "miun.afs8435.0001.001"
+        namespace, id = extract_namespace_and_id(document_id)
+        assert namespace == "miun"
+        assert id == "afs8435.0001.001"
+
+        document_id = "uiug.30112056400960"
+        namespace, id = extract_namespace_and_id(document_id)
+        assert namespace == "uiug"
+        assert id == "30112056400960"

--- a/document_generator/full_text_document_generator.py
+++ b/document_generator/full_text_document_generator.py
@@ -1,11 +1,11 @@
 import zipfile
 import time
-import os
 
 from document_generator.mysql_data_extractor import MysqlMetadataExtractor
 from ht_utils.ht_mysql import HtMysql
 from ht_utils.ht_logger import get_ht_logger
 from ht_utils.text_processor import string_preparation
+from pathlib import Path
 
 import xml.sax.saxutils
 
@@ -25,6 +25,8 @@ def extract_fields_from_mets_file(doc_source_path) -> dict:
     """
     mets_fields = {}
     try:
+        if not Path(f"{doc_source_path}.mets.xml").is_file():
+            raise FileNotFoundError(f"File {doc_source_path}.mets.xml not found")
         mets_obj = document_generator.mets_file_extractor.MetsAttributeExtractor(f"{doc_source_path}.mets.xml")
         mets_entry = mets_obj.create_mets_entry()
 
@@ -100,7 +102,9 @@ class FullTextDocumentGenerator:
 
         logger.info("=================")
         logger.info(f"Document path {zip_doc_path}")
-        if not os.path.isfile(zip_doc_path):
+
+        file_path = Path(zip_doc_path)
+        if not file_path.is_file():
             raise FileNotFoundError(f"File {zip_doc_path} not found")
 
         zip_doc = zipfile.ZipFile(zip_doc_path, mode="r")

--- a/document_generator/mysql_data_extractor.py
+++ b/document_generator/mysql_data_extractor.py
@@ -23,6 +23,21 @@ def create_ht_heldby_field(heldby_brlm: list[tuple]) -> dict:
     return {"ht_heldby": list_brl_members}
 
 
+def extract_namespace_and_id(document_id: str):
+    """
+    Extracts the namespace and the id from a given document id string.
+    The namespace is defined as the characters before the first period.
+    The id is the remainder of the string after the first period.
+
+    :param document_id: The document id string to extract from.
+    :return: A tuple containing the namespace and the id.
+    """
+    parts = document_id.split(".", 1)  # Split at the first period only
+    namespace = parts[0] if parts else None
+    id = parts[1] if len(parts) > 1 else None
+    return namespace, id
+
+
 class MysqlMetadataExtractor:
     def __init__(self, db_conn: HtMysql):
         self.mysql_obj = db_conn
@@ -63,7 +78,8 @@ class MysqlMetadataExtractor:
 
     def add_rights_field(self, doc_id) -> list[tuple]:
 
-        namespace, _id = doc_id.split(".")
+        namespace, _id = extract_namespace_and_id(doc_id)
+
         query = (
             f'SELECT * FROM rights_current WHERE namespace="{namespace}" AND id="{_id}"'
         )

--- a/ht_document/ht_document.py
+++ b/ht_document/ht_document.py
@@ -6,7 +6,6 @@ from pypairtree import pairtree
 from ht_utils.ht_logger import get_ht_logger
 from indexer_config import (
     DOCUMENT_LOCAL_PATH,
-    TRANSLATE_TABLE,
     LOCAL_DOCUMENT_FOLDER
 )
 
@@ -35,14 +34,13 @@ class HtDocument:
         # If there are special characters in the document_id, the file will be load in the local
         # environment with a different name
         self.file_name = pairtree.sanitizeString(self.obj_id)
-        self.sanitized_obj_id_translated = self.file_name.translate(TRANSLATE_TABLE)
 
         # By default path files are in /sdr1/obj
         if document_repository == 'pairtree':
             self.source_path = f"{os.environ.get('SDR_DIR')}/{self.namespace}/pairtree_root{self.get_document_pairtree_path()}"  # /sdr1/obj/
         else:
             # A sample_data will be in the same folder of the repository
-            self.source_path = f"{LOCAL_DOCUMENT_FOLDER}/{self.sanitized_obj_id_translated}"
+            self.source_path = f"{LOCAL_DOCUMENT_FOLDER}/{self.file_name}"
 
         self.target_path = f"{DOCUMENT_LOCAL_PATH}{self.file_name}"
 
@@ -73,13 +71,6 @@ class HtDocument:
         """
 
         # Use the file name to get the pairtree path
-        doc_pairtree_path = pairtree.get_pair_path(self.file_name)
-
-        # Escape special characters from the file of the path and the object name
-        doc_translated_path = doc_pairtree_path.translate(TRANSLATE_TABLE)
-        # sanitized_obj_id_translated = self.file_name.translate(TRANSLATE_TABLE)
-
-        # source_path = f"{SDR_DIR}/{self.namespace}/pairtree_root{doc_translated_path}/{sanitized_obj_id_translated}"
-        doc_path = f"{doc_translated_path}/{self.sanitized_obj_id_translated}"
-
+        doc_pairtree_path = pairtree.toPairTreePath(self.obj_id)
+        doc_path = f"/{doc_pairtree_path}{pairtree.sanitizeString(self.obj_id)}/{self.file_name}"
         return doc_path

--- a/ht_document/ht_document_test.py
+++ b/ht_document/ht_document_test.py
@@ -29,8 +29,30 @@ def test_get_namespace():
 
 
 def test_get_object_id():
-    namespace = HtDocument.get_object_id("uc2.ark:/13960/t4mk66f1d")
-    assert namespace == "ark:/13960/t4mk66f1d"
+    object_id = HtDocument.get_object_id("uc2.ark:/13960/t4mk66f1d")
+    assert object_id == "ark:/13960/t4mk66f1d"
+
+
+def test_colon_name_pattern():
+    """Test the pattern with a colon in the name
+    Check if the namespace, object id and pairtree path are correctly extracted
+    """
+    namespace = HtDocument.get_namespace("coo1.ark:/13960/t57d3f780")
+    assert namespace == "coo1"
+
+    obj_id = HtDocument.get_object_id("coo1.ark:/13960/t57d3f780")
+    assert obj_id == "ark:/13960/t57d3f780"
+
+    os.environ["SDR_DIR"] = "/sdr1/obj"
+    ht_doc = HtDocument(document_id="coo1.ark:/13960/t57d3f780", document_repository="pairtree")
+
+    doc_path = ht_doc.get_document_pairtree_path()
+    assert doc_path == r"/ar/k+/=1/39/60/=t/57/d3/f7/80/ark+=13960=t57d3f780/ark+=13960=t57d3f780"
+    # assert doc_path == r"/ar/k+/\=1/39/60/\=t/57/d3/f7/80/ark+\=13960\=t57d3f780/ark+\=13960\=t57d3f780"
+
+    # source_path includes the name of the file
+    # assert r"/sdr1/obj/coo1/pairtree_root/ar/k+/\=1/39/60/\=t/57/d3/f7/80/ark+\=13960\=t57d3f780/ark+\=13960\=t57d3f780" == ht_doc.source_path
+    assert r"/sdr1/obj/coo1/pairtree_root/ar/k+/=1/39/60/=t/57/d3/f7/80/ark+=13960=t57d3f780/ark+=13960=t57d3f780" == ht_doc.source_path
 
 
 def test_document_several_points():
@@ -62,4 +84,3 @@ def test_document_filesystem_folder():
     assert ht_doc.target_path == "/tmp/39015078560292_test"
     assert ht_doc.namespace == "mb"
     assert ht_doc.file_name == "39015078560292_test"
-    # assert ht_doc.source_path == f"{os.environ.get('SDR_DIR')}/{ht_doc.file_name}"

--- a/ht_document/ht_pairtree.py
+++ b/ht_document/ht_pairtree.py
@@ -1,15 +1,27 @@
+import inspect
 import os
 import subprocess
 import sys
 
+current = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+parent = os.path.dirname(current)
+sys.path.insert(0, parent)
+
+from pathlib import Path
+
+from ht_document.ht_document import HtDocument
 from ht_utils.ht_logger import get_ht_logger
 
 logger = get_ht_logger(name=__name__)
 
 
 def download_document_file(
-        source_path: str = None, target_path: str = None, extension: str = "zip"
+        ht_id: str = None, target_path: str = None, extension: str = "zip"
 ):
+    os.environ["SDR_DIR"] = '/sdr1/obj'
+
+    ht_doc = HtDocument(document_id=ht_id, document_repository="pairtree")
+    source_path = ht_doc.source_path
     try:
         public_key = os.environ["PUBLIC_KEY"]
     except KeyError:
@@ -35,4 +47,9 @@ def download_document_file(
         f"{target_path}.{extension}",
     ]
     subprocess.run(command)
-    logger.info(f"Download {source_path}.{extension} to {target_path}")
+    print(f"Download {source_path}.{extension} to {target_path}")
+
+
+if __name__ == "__main__":
+    download_document_file(ht_id="coo1.ark:/13960/t57d3f780", target_path=str(Path(__file__).parents[1]),
+                           extension="zip")

--- a/indexer_config.py
+++ b/indexer_config.py
@@ -9,8 +9,6 @@ DOCUMENT_LOCAL_PATH = "/tmp/"
 # Variables to manage IO operations, local folder with files
 LOCAL_DOCUMENT_FOLDER = f"{Path(__file__).parents[1]}/sdr1/obj"
 
-TRANSLATE_TABLE = str.maketrans({"=": r"\=", ",": r"\,"})
-
 # field_full_text : field catalog
 RENAMED_CATALOG_METADATA = {
     "record_no": "id",


### PR DESCRIPTION
This PR fixed issues reported on this [task](https://hathitrust.atlassian.net/browse/DEV-1234)

The main changes are:

- Improve the logic to get the pair-tree path
   - Use pypairtree function to sanitize the pair-tree path;
   - Use Pathlib package to check if the file exists in the pair-tree path repository;
- Removed unnecessary dependencies from containers;
- Fixed an issue getting namespace and id to query MySQL
- Some unitests were updated, and new tests were added.

The first two stages of ht_indexer are running in Kubernetes to check for new issues retrieving documents from Solr and generating the full-text documents. You can see in the attached images that there are no issues at the moment, I am publishing this PR. I will continue monitoring this process. 

![image](https://github.com/hathitrust/ht_indexer/assets/47088146/9a78388c-fac1-4081-8abc-0920f4c6dc9b)


How to test it?

**Clone the repository**
`git clone ... or git fetch`

**Use the branch of this PR**
`git checkout -b DEV-1234-fix_pairtree_path`

In the working directory,

**3.1. Create the image**
`docker build -t document_generator .`

**3.2. Run the container**
`docker compose up document_generator -d`

**3.3. Run Python tests related to document_generator_service**
`docker compose exec document_generator pytest document_generator ht_document ht_queue_service ht_utils`

If you see the image below in your terminal, the PR is working fine.

![image](https://github.com/hathitrust/ht_indexer/assets/47088146/7e911999-5890-4b1f-9cd5-de2f0d927280)
