### PR TITLE
Reduce the time to generate the OCR field

### DIFF
--- a/document_generator/document_generator_service.py
+++ b/document_generator/document_generator_service.py
@@ -55,21 +55,18 @@ class DocumentGeneratorService:
         if not Path(f"{ht_document.source_path}.zip").is_file():
             # The message is rejected because the file with the text of the document does not exist
             # then, entry dictionary could not be generated
-            logger.info(f"The file of the document {ht_document.document_id} does not exist")
-            raise FileNotFoundError(f"File {ht_document.source_path}.zip not found")
-        logger.info(f"{ht_document.source_path}.zip exists!")
-        logger.info(f"Processing item {ht_document.document_id}")
+            raise FileNotFoundError(f"The file of the ht_id={ht_document.document_id} on the path={ht_document.source_path}.zip not found")
+        logger.info(f"Processing item {ht_document.document_id} using {ht_document.source_path}.zip")
         try:
             entry = self.document_generator.make_full_text_search_document(ht_document, record)
         except Exception as e:
             raise Exception(f"Document {ht_document.document_id} could not be generated: Error - {e}")
-        logger.info(
-            f"Time to generate process=full-text_document ht_id={ht_document.document_id} Time={time.time() - start_time:.10f}")
 
         # Use to get the size of the entry dictionary
         entry_data = json.dumps(entry)
         entry_size = len(entry_data.encode('utf-8'))  # Convert to bytes and get length
-        logger.info(f"Serialized JSON process=full-text_document ht_id={ht_document.document_id} Size={entry_size} bytes")
+        logger.info(f"Time to generate process=full-text_document ht_id={ht_document.document_id} "
+                    f"Time={time.time() - start_time:.10f} Size={entry_size} bytes")
 
         return entry
 

--- a/document_generator/full_text_document_generator.py
+++ b/document_generator/full_text_document_generator.py
@@ -78,18 +78,17 @@ class FullTextDocumentGenerator:
         # check the logs te see the among of files with this messages to determine if we need the line
         # if not i_file.startswith('__MACOSX/') or if we need to include a resource forks in the code
         # python library to handle resource forks => phttps://pypi.org/project/rsrcfork/
-        full_text = ""
+        full_text_parts = []
         macosx_files = False
         for i_file in zip_doc.namelist():
             if not i_file.startswith('__MACOSX/'):
                 if zip_doc.getinfo(i_file).filename.endswith(".txt"):
-                    full_text = (
-                            full_text + " " + string_preparation(zip_doc.read(i_file))
-                    )
+                    full_text_parts.append(string_preparation(zip_doc.read(i_file)))
             else:
                 macosx_files = True
-        logger.info(f"{zip_doc.filename} contains __MACOSX directory")
-        return full_text
+        if macosx_files:
+            logger.info(f"{zip_doc.filename} contains __MACOSX directory")
+        return " ".join(full_text_parts)
 
     @staticmethod
     def get_full_text_field(zip_doc_path: str):
@@ -100,15 +99,14 @@ class FullTextDocumentGenerator:
         :return: String concatenated all the content of the .TXT files
         """
 
-        logger.info("=================")
         logger.info(f"Document path {zip_doc_path}")
 
         file_path = Path(zip_doc_path)
         if not file_path.is_file():
             raise FileNotFoundError(f"File {zip_doc_path} not found")
 
-        zip_doc = zipfile.ZipFile(zip_doc_path, mode="r")
-        full_text = FullTextDocumentGenerator.txt_files_2_full_text(zip_doc).encode().decode()
+        with zipfile.ZipFile(zip_doc_path, mode="r") as zip_doc:
+            full_text = FullTextDocumentGenerator.txt_files_2_full_text(zip_doc)
         return full_text
 
     @staticmethod

--- a/document_indexer_service/document_indexer_service.py
+++ b/document_indexer_service/document_indexer_service.py
@@ -40,19 +40,20 @@ class DocumentIndexerQueueService:
             # Use to get the size of the entry dictionary
             entry_data = json.dumps(message)
             entry_size = len(entry_data.encode('utf-8'))  # Convert to bytes and get length
-            logger.info(
-                f"Serialized JSON process=indexing ht_id={message.get('id')} Size={entry_size} bytes")
 
             try:
                 logger.info(f"Retrieving the item {message.get('id')} from {self.queue_consumer.queue_name}")
                 response = self.storage_document(json_object=message)
                 logger.info(
-                    f"Success process=indexing the item ht_id={message.get('id')}. Operation status: {response.status_code} Time={time.time() - start_time:.10f}")
+                    f"Success process=indexing the item ht_id={message.get('id')}. "
+                    f"Operation status: {response.status_code} Time={time.time() - start_time:.10f} "
+                    f"Size={entry_size} bytes")
                 positive_acknowledge(self.queue_consumer.conn.ht_channel, method_frame.delivery_tag)
             except Exception as e:
                 error_info = ht_utils.get_error_message_by_document("IndexerService",
                                                                     e, message)
-                logger.error(f"Document={message.get('ht_id')} failed {error_info} Time={time.time() - start_time:.10f}")
+                logger.error(f"Document={message.get('ht_id')} failed {error_info} "
+                             f"Time={time.time() - start_time:.10f} Size={entry_size} bytes")
                 self.queue_consumer.reject_message(self.queue_consumer.conn.ht_channel, method_frame.delivery_tag)
 
 


### PR DESCRIPTION
The following changes were applied to this PR to reduce the time to generate the OCR field. 

* Use a list to collect the text, instead of string concatenation
* Remove redundant encoding and decoding operations
* Use content management to open the zip file. 
* Remove some redundant logs

In the following picture, you can see how most of the time, the full-text document is in the process of generating the ORC field.

![image](https://github.com/user-attachments/assets/8f47ffe7-a477-419e-a3c7-59d7e0b3051a)

I used seven documents to measure the time to generate the OCR field. Before this PR, around 0.38 seconds to generate the OCR field, after the PR ~0.16 seconds.

**Steps to test this PR**,

```docker build -t document_generator .```
```docker compose up document_generator -d```
```docker compose exec document_generator pytest document_generator ht_document ht_queue_service ht_utils```