### PR TITLE
Speed up document_generator removing threads and using replace for str…

### DIFF
--- a/document_generator/full_text_document_generator.py
+++ b/document_generator/full_text_document_generator.py
@@ -1,6 +1,5 @@
 import zipfile
 import time
-from concurrent.futures import ThreadPoolExecutor
 
 from document_generator.mysql_data_extractor import MysqlMetadataExtractor
 from ht_utils.ht_mysql import HtMysql
@@ -74,17 +73,12 @@ class FullTextDocumentGenerator:
         Read all .TXT files in a zip and concatenate their contents.
         :return: Single string with all text files concatenated.
         """
-        macosx_files = any(i_file.startswith('__MACOSX/') for i_file in zip_doc.namelist())
 
         # Get only .txt files and sort them by name
         txt_files = sorted([i_file for i_file in zip_doc.namelist() if
                      i_file.endswith('.txt') and not i_file.startswith('__MACOSX/')])
 
         full_text_parts = [string_preparation(zip_doc.read(f)) for f in txt_files]
-
-        # Log if __MACOSX was found
-        if macosx_files:
-            logger.info(f"{zip_doc.filename} contains __MACOSX directory")
 
         return " ".join(full_text_parts)
 

--- a/ht_utils/text_processor.py
+++ b/ht_utils/text_processor.py
@@ -1,6 +1,8 @@
 import re
+from datetime import time
 from typing import Dict, List
 from xml.sax.saxutils import quoteattr
+import time
 
 from ht_utils.ht_logger import get_ht_logger
 
@@ -39,9 +41,8 @@ def string_preparation(doc_content: bytes) -> str:
         logger.error(f"File encoding incompatible with UTF-8: {e}")
         raise e
 
-    # Use regex once to remove line breaks and extra spaces
-    str_content = re.sub(r"\s+", " ", str_content)
-
+    # Remove line breaks and extra spaces
+    str_content = str_content.replace('\r', '').replace('\n', '')
     return quoteattr(str_content)
 
 


### PR DESCRIPTION
This PR consists of speeding up document_generator removing the thread process to read the files inside the zip file and using the replace method to process the string instead of using re.sub.

The following approaches were tested to generate the ORC field. 

* Use replace to remove line breaks and extra spaces
* Use regex (re.sub) to remove line breaks and extra spaces
* Process Txt files in sequence (simple loop)
* Use ThreadPoolExecutor to process TXT files in parallel (a good option for I/O-bound operations)
In our code the zip_doc.read(f) is not truly I/O-bound and instead happens in memory, threading may introduce overhead rather than speedup.
* Group files into batches and process them in chunks (Good for zip files with a long list of TXTs)
* Use ProcessPoolExecutor if string_preparation is CPU-Intensive

The best performance was combining a simple loop and the method replaced for string preparation.

In the confluence page you will find the results of these experiments. 





 